### PR TITLE
Jingo has sane defaults for JINGO_EXCLUDE_APPS setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ edit the generated `requirements.txt` file and remove the lines about
 use. You will also need to edit the `.travis.yml` file accordingly.
 
 * If you don't want to use **Jinja2**, remove the lines about `jingo`,
-`MarkupSafe` and `Jinja2` in the `requirements.txt` file. You will also
-need to edit the file `settings/base.py` and remove
-the `TEMPLATE_LOADERS` and the `JINGO_EXCLUDE_APPS` setting.
+`MarkupSafe` and `Jinja2` in the `requirements.txt` file. You will
+also need to edit the file `settings/base.py` and remove the
+`TEMPLATE_LOADERS` setting.
 
 * if you want to use **pytest instead of nose**, remove `nose` and
 `django-nose` from `requirements.txt` then add in `pytest`, `py`,

--- a/sugardough/sugardough/settings/base.py
+++ b/sugardough/sugardough/settings/base.py
@@ -106,10 +106,6 @@ TEMPLATE_LOADERS = (
     'django.template.loaders.app_directories.Loader',
 )
 
-JINGO_EXCLUDE_APPS = [
-    'admin',
-]
-
 # Django-CSP
 CSP_DEFAULT_SRC = (
     "'self'",

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings/base.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings/base.py
@@ -106,10 +106,6 @@ TEMPLATE_LOADERS = (
     'django.template.loaders.app_directories.Loader',
 )
 
-JINGO_EXCLUDE_APPS = [
-    'admin',
-]
-
 # Django-CSP
 CSP_DEFAULT_SRC = (
     "'self'",


### PR DESCRIPTION
I just learned from @jgmize that Jingo has a default setting for JINGO_EXCLUDE_APPS which includes `admin`, `admindocs` and `registration` apps. There's no need for us to overwrite this.

Reference jbalogh/jingo#22
