### PR TITLE
Run sugardough tests in docker.

### DIFF
--- a/bin/test_sugardough_docker.sh
+++ b/bin/test_sugardough_docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+TDIR=`mktemp -d`
+virtualenv $TDIR
+. $TDIR/bin/activate
+pip install tox cookiecutter
+TOX_ENV=dockertests ./bin/test_sugardough.sh

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -27,3 +27,9 @@ deps =
     sphinx-rtd-theme
     sphinx-autobuild
 commands = make -C docs html
+
+[testenv:dockertests]
+deps =
+    docker-compose
+commands =
+    docker-compose run -T web ./manage.py test


### PR DESCRIPTION
Running the tests only on travis is not enough because we don't test the docker image build procedure.

I temporarily created a job here https://ci.masterfirefoxos.com/job/sugardough/ until we move this CI to a proper place.