### PR TITLE
Add user in dockerfile.

### DIFF
--- a/{{ cookiecutter.project_name }}/Dockerfile
+++ b/{{ cookiecutter.project_name }}/Dockerfile
@@ -19,7 +19,8 @@ WORKDIR /app
 # docker caching.
 COPY ./bin/peep.py /app/bin/peep.py
 COPY requirements.txt /app/requirements.txt
-RUN ./bin/peep.py install -r requirements.txt
+# Pin a known to work with peep pip version.
+RUN pip install pip==6.1.1 && ./bin/peep.py install -r requirements.txt
 
 USER webdev
 COPY . /app

--- a/{{ cookiecutter.project_name }}/Dockerfile
+++ b/{{ cookiecutter.project_name }}/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3-slim
 EXPOSE 8000
 CMD ["./bin/run-prod.sh"]
 
+RUN adduser --uid 1000 --disabled-password --gecos '' webdev && \
+    chown -R webdev:webdev /app
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential python-dev libpq-dev postgresql-client gettext && \
     rm -rf /var/lib/apt/lists/*
@@ -18,5 +21,6 @@ COPY ./bin/peep.py /app/bin/peep.py
 COPY requirements.txt /app/requirements.txt
 RUN ./bin/peep.py install -r requirements.txt
 
+USER webdev
 COPY . /app
 RUN DEBUG=False SECRET_KEY=foo ALLOWED_HOSTS=localhost, DATABASE_URL= ./manage.py collectstatic --noinput -c


### PR DESCRIPTION
Besides being a better practice, this also solves the permission problem
with mounted volumes when using docker-compose, since the user in the
container has uid=1000 which is the default uid of the first user for
the most common linux distributions.