### PR TITLE
Extra ! in TEMPLATE match_regex setting causes error in admin site

### DIFF
--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings.py
@@ -104,7 +104,7 @@ TEMPLATES = [
         'BACKEND': 'django_jinja.backend.Jinja2',
         'APP_DIRS': True,
         'OPTIONS': {
-            'match_regex': r'^(?!!(admin|registration)/.*)',
+            'match_regex': r'^(?!(admin|registration)/.*)',
             'match_extension': '.html',
             'newstyle_gettext': True,
             'context_processors': [


### PR DESCRIPTION
Removing one of the two `!`'s seems to fix my error with the admin site