### PR TITLE
Set debian:jessie as base docker image.

### DIFF
--- a/{{ cookiecutter.project_name }}/Dockerfile
+++ b/{{ cookiecutter.project_name }}/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM debian:jessie
 
 EXPOSE 8000
 CMD ["./bin/run-prod.sh"]
@@ -6,8 +6,12 @@ CMD ["./bin/run-prod.sh"]
 RUN adduser --uid 1000 --disabled-password --gecos '' --no-create-home webdev
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential python-dev libpq-dev postgresql-client gettext && \
+    apt-get install -y --no-install-recommends build-essential python3 python3-dev python3-pip \
+                                               libpq-dev postgresql-client gettext && \
     rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
 
 # Using PIL or Pillow? You probably want to uncomment next line
 # RUN apt-get update && apt-get install -y --no-install-recommends libjpeg8-dev


### PR DESCRIPTION
Starting from python docker images and then apt-get installing python
packages will cause multiple python versions to be installed. Debian
Jessie has a recent Python version (3.4) and we can directly use that.