### PR TITLE
Stop containers after test

### DIFF
--- a/bin/test_sugardough_docker.sh
+++ b/bin/test_sugardough_docker.sh
@@ -22,5 +22,9 @@ $DC_CMD run -T web flake8 sugardough
 # Run Tests
 $DC_CMD run -T web ./manage.py test
 
+# Stop containers
+# TODO: cleanup job to stop containers left over from failed tests
+$DC_CMD stop
+
 # Delete virtualenv
 rm -rf $TDIR $ENVDIR


### PR DESCRIPTION
While working on a separate issue, I noticed that our Jenkins instance had a bunch of sugardough test containers running. I manually killed them with `sudo docker ps | grep sugardough | awk '{print $11}' | xargs sudo docker stop`, and I'm filing this PR as a first step to reduce the issue. We may also need to make some adjustments to the docker cleanup task we run nightly on the jenkins server to stop containers from failed jobs.