### PR TITLE
Add CACHES default settings, fixes #56

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - 3.4
 addons:
   postgresql: "9.3"
+services:
+  - redis-server
 before_script:
   - createdb sugardough_db
 install:

--- a/{{ cookiecutter.project_name }}/.travis.yml
+++ b/{{ cookiecutter.project_name }}/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
 addons:
   postgresql: "9.4"
+services:
+  - redis-server
 before_script:
   - createdb {{ cookiecutter.project_db }}
 install:

--- a/{{ cookiecutter.project_name }}/Dockerfile
+++ b/{{ cookiecutter.project_name }}/Dockerfile
@@ -28,6 +28,6 @@ COPY requirements.txt /app/requirements.txt
 RUN ./bin/peep.py install -r requirements.txt
 
 COPY . /app
-RUN DEBUG=False SECRET_KEY=foo ALLOWED_HOSTS=localhost, DATABASE_URL= ./manage.py collectstatic --noinput -c
+RUN DEBUG=False SECRET_KEY=foo ALLOWED_HOSTS=localhost, DATABASE_URL=, REDIS_URL= ./manage.py collectstatic --noinput -c
 RUN chown webdev.webdev -R .
 USER webdev

--- a/{{ cookiecutter.project_name }}/docker-compose.yml
+++ b/{{ cookiecutter.project_name }}/docker-compose.yml
@@ -1,5 +1,7 @@
 db:
   image: postgres:9.4
+cache:
+  image: redis:3.0.5
 web:
   build: .
   ports:
@@ -8,9 +10,11 @@ web:
     - .:/app
   links:
     - db
+    - cache
   environment:
     - PYTHONDONTWRITEBYTECODE=1
     - DATABASE_URL=postgres://postgres@db/postgres
+    - REDIS_URL=redis://cache:6379
     - DEBUG=True
     - ALLOWED_HOSTS=localhost,127.0.0.1,
     - SECRET_KEY=59114b6a-2858-4caf-8878-482a24ee9542

--- a/{{ cookiecutter.project_name }}/requirements.txt
+++ b/{{ cookiecutter.project_name }}/requirements.txt
@@ -109,3 +109,10 @@ django-jinja==1.4.1
 
 # sha256: RORjnsBXprap3duGnU46SBj8knjsSQzOOa7whEBZKpM
 django-session-csrf==0.5
+
+# sha256: nQ-cEz2G_JTiRTxceRkbRiDdOGVQx80Nu1m6vG3sD8k
+django-redis-cache==1.6.4
+
+# sha256: lxVrN9fNpOfYZYvhFIyYOYThqXUJC6RYzH4kQCUZHb0
+# sha256: Xfuuas_FTt8KekFbmeCyHAo8J6f3h7KS7qcnsfrMVTM
+redis==2.10.5

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -8,6 +8,7 @@ setenv =
     SECRET_KEY='FOO'
     ALLOWED_HOSTS=localhost
     DATABASE_URL=postgres://localhost/{{ cookiecutter.project_db }}
+    REDIS_URL=redis://localhost:6379
 
 [testenv:tests]
 deps =

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings.py
@@ -9,6 +9,10 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
 import os
+try:
+    import urlparse as parse
+except:
+    from urllib import parse
 
 import dj_database_url
 from decouple import Csv, config
@@ -77,6 +81,24 @@ DATABASES = {
         cast=dj_database_url.parse
     )
 }
+
+# cache
+# https://docs.djangoproject.com/en/1.7/ref/settings/#caches
+redis_url = config(
+    'REDIS_URL',
+    cast=parse.urlparse
+)
+CACHES = {
+    "default": {
+        "BACKEND": "redis_cache.RedisCache",
+        "LOCATION": "{0}:{1}".format(redis_url.hostname, redis_url.port),
+        "OPTIONS": {
+            "PASSWORD": redis_url.password,
+            "DB": 0,
+        }
+    }
+}
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/


### PR DESCRIPTION
This patch adds a new redis container and a couple of libraries to
interact with it.
The environment variable REDIS_URL should be compatible with the heroku
redis plugin, so in thoery it *should* work there as well (not tested
though).