### PR TITLE
Wait for database to become available.

### DIFF
--- a/bin/test_sugardough_docker.sh
+++ b/bin/test_sugardough_docker.sh
@@ -7,7 +7,7 @@ set -ex
 ENVDIR=`mktemp -d`
 virtualenv $ENVDIR
 . $ENVDIR/bin/activate
-pip install cookiecutter docker-compose==1.2.0
+pip install cookiecutter docker-compose
 
 TDIR=`mktemp -d`
 cp cookiecutter.json $TDIR/
@@ -15,9 +15,22 @@ cd $TDIR
 cookiecutter --no-input $OLDPWD
 cd sugardough
 
-DC_CMD="docker-compose --project-name jenkins${JOB_NAME}${BUILD_NUMBER}"
+PROJECT_NAME=`echo "jenkins${JOB_NAME}${BUILD_NUMBER}" | sed s/_//g`
+DC_CMD="docker-compose --project-name $PROJECT_NAME"
 
 $DC_CMD run -T web flake8 sugardough
+
+# Wait for database
+$DC_CMD run -d db
+while true;
+do
+    CMD="docker run --link ${PROJECT_NAME}_db_1:db multicloud/netcat -z db 5432"
+    if eval ${CMD};
+    then
+        break;
+    fi;
+    sleep 1s;
+done;
 
 # Run Tests
 $DC_CMD run -T web ./manage.py test


### PR DESCRIPTION
Directly running docker-compose run will bring up the database but it
may be still initializing when Django attempts to connect causing the
tests to fail.

This change will wait for the database port to open before continuing
with the test commands.