### PR TITLE
Turn off NR browser auto instrument.

### DIFF
--- a/{{ cookiecutter.project_name }}/newrelic.ini
+++ b/{{ cookiecutter.project_name }}/newrelic.ini
@@ -175,7 +175,7 @@ error_collector.ignore_errors =
 # For those Python web frameworks that are supported, this
 # setting enables the auto-insertion of the browser monitoring
 # JavaScript fragments.
-browser_monitoring.auto_instrument = true
+browser_monitoring.auto_instrument = false
 
 # A thread profiling session can be scheduled via the UI when
 # this option is enabled. The thread profiler will periodically


### PR DESCRIPTION
Per discussion in webdev mailing list NR does not offer an acceptable
opt-out mechanism for users and therefore should not be used.