### PR TITLE
very small typo fix in README.md - build should be built

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Sugardough
 ==========
 
 Sugardough is a web application template based on Django. Sugardough is
-build using [Cookiecutter](https://github.com/audreyr/cookiecutter).
+built using [Cookiecutter](https://github.com/audreyr/cookiecutter).
 
 Features:
  * Django settings with environment variables, using [Decouple](https://github.com/henriquebastos/python-decouple)


### PR DESCRIPTION
"build using Cookiecutter" should be "built using Cookiecutter"
